### PR TITLE
Adds Travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,46 @@
+language: c
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+    - libmysqlclient-dev
+
+env:
+  global:
+    - LUAROCKS=2.2.2
+    - DB_DRIVER=mysql
+    - DB_USER=travis
+    #- DB_PASS=
+    - DB_NAME=sailor_test
+
+  matrix:
+    - LUA=lua5.1
+    - LUA=lua5.2
+    - LUA=lua5.3
+    - LUA=luajit     # latest stable version (2.0.4)
+    # - LUA=luajit2.0  # current head of 2.0 branch
+    # - LUA=luajit2.1  # current head of 2.1 branch
+
+
+before_install:
+  - source .travis/setenv_lua.sh
+  - luarocks install luasql-mysql MYSQL_INCDIR=/usr/include/mysql
+
+install:
+  - luarocks make rockspecs/sailor-0.5-1.rockspec
+
+before_script:
+  - mysql -e 'create database sailor_test;'
+  - mysql $DB_NAME < test/dev-app/sql/mysql.sql
+
+script:
+  - cd test/dev-app
+  - sailor test --verbose
+  #- busted --helper=tests/bootstrap.lua --verbose tests/unit/* tests/functional/*
+
+notifications:
+  email:
+    on_success: change
+    on_failure: always

--- a/.travis/platform.sh
+++ b/.travis/platform.sh
@@ -1,0 +1,15 @@
+if [ -z "${PLATFORM:-}" ]; then
+  PLATFORM=$TRAVIS_OS_NAME;
+fi
+
+if [ "$PLATFORM" == "osx" ]; then
+  PLATFORM="macosx";
+fi
+
+if [ -z "$PLATFORM" ]; then
+  if [ "$(uname)" == "Linux" ]; then
+    PLATFORM="linux";
+  else
+    PLATFORM="macosx";
+  fi;
+fi

--- a/.travis/setenv_lua.sh
+++ b/.travis/setenv_lua.sh
@@ -1,0 +1,3 @@
+export PATH=${PATH}:$HOME/.lua:$HOME/.local/bin:${TRAVIS_BUILD_DIR}/install/luarocks/bin
+bash .travis/setup_lua.sh
+eval `$HOME/.lua/luarocks path`

--- a/.travis/setup_lua.sh
+++ b/.travis/setup_lua.sh
@@ -1,0 +1,121 @@
+#! /bin/bash
+
+# A script for setting up environment for travis-ci testing.
+# Sets up Lua and Luarocks.
+# LUA must be "lua5.1", "lua5.2" or "luajit".
+# luajit2.0 - master v2.0
+# luajit2.1 - master v2.1
+
+set -eufo pipefail
+
+LUAJIT_BASE="LuaJIT-2.0.4"
+
+source .travis/platform.sh
+
+LUA_HOME_DIR=$TRAVIS_BUILD_DIR/install/lua
+
+LR_HOME_DIR=$TRAVIS_BUILD_DIR/install/luarocks
+
+mkdir $HOME/.lua
+
+LUAJIT="no"
+
+if [ "$PLATFORM" == "macosx" ]; then
+  if [ "$LUA" == "luajit" ]; then
+    LUAJIT="yes";
+  fi
+  if [ "$LUA" == "luajit2.0" ]; then
+    LUAJIT="yes";
+  fi
+  if [ "$LUA" == "luajit2.1" ]; then
+    LUAJIT="yes";
+  fi;
+elif [ "$(expr substr $LUA 1 6)" == "luajit" ]; then
+  LUAJIT="yes";
+fi
+
+mkdir -p "$LUA_HOME_DIR"
+
+if [ "$LUAJIT" == "yes" ]; then
+
+  if [ "$LUA" == "luajit" ]; then
+    curl http://luajit.org/download/$LUAJIT_BASE.tar.gz | tar xz;
+  else
+    git clone http://luajit.org/git/luajit-2.0.git $LUAJIT_BASE;
+  fi
+
+  cd $LUAJIT_BASE
+
+  if [ "$LUA" == "luajit2.1" ]; then
+    git checkout v2.1;
+    # force the INSTALL_TNAME to be luajit
+    perl -i -pe 's/INSTALL_TNAME=.+/INSTALL_TNAME= luajit/' Makefile
+  fi
+
+  make && make install PREFIX="$LUA_HOME_DIR"
+
+  ln -s $LUA_HOME_DIR/bin/luajit $HOME/.lua/luajit
+  ln -s $LUA_HOME_DIR/bin/luajit $HOME/.lua/lua;
+
+else
+
+  if [ "$LUA" == "lua5.1" ]; then
+    curl http://www.lua.org/ftp/lua-5.1.5.tar.gz | tar xz
+    cd lua-5.1.5;
+  elif [ "$LUA" == "lua5.2" ]; then
+    curl http://www.lua.org/ftp/lua-5.2.4.tar.gz | tar xz
+    cd lua-5.2.4;
+  elif [ "$LUA" == "lua5.3" ]; then
+    curl http://www.lua.org/ftp/lua-5.3.1.tar.gz | tar xz
+    cd lua-5.3.1;
+  fi
+
+  # Build Lua without backwards compatibility for testing
+  perl -i -pe 's/-DLUA_COMPAT_(ALL|5_2)//' src/Makefile
+  make $PLATFORM
+  make INSTALL_TOP="$LUA_HOME_DIR" install;
+
+  ln -s $LUA_HOME_DIR/bin/lua $HOME/.lua/lua
+  ln -s $LUA_HOME_DIR/bin/luac $HOME/.lua/luac;
+
+fi
+
+cd $TRAVIS_BUILD_DIR
+
+lua -v
+
+LUAROCKS_BASE=luarocks-$LUAROCKS
+
+curl --location http://luarocks.org/releases/$LUAROCKS_BASE.tar.gz | tar xz
+
+cd $LUAROCKS_BASE
+
+if [ "$LUA" == "luajit" ]; then
+  ./configure --lua-suffix=jit --with-lua-include="$LUA_HOME_DIR/include/luajit-2.0" --prefix="$LR_HOME_DIR";
+elif [ "$LUA" == "luajit2.0" ]; then
+  ./configure --lua-suffix=jit --with-lua-include="$LUA_HOME_DIR/include/luajit-2.0" --prefix="$LR_HOME_DIR";
+elif [ "$LUA" == "luajit2.1" ]; then
+  ./configure --lua-suffix=jit --with-lua-include="$LUA_HOME_DIR/include/luajit-2.1" --prefix="$LR_HOME_DIR";
+else
+  ./configure --with-lua="$LUA_HOME_DIR" --prefix="$LR_HOME_DIR"
+fi
+
+make build && make install
+
+ln -s $LR_HOME_DIR/bin/luarocks $HOME/.lua/luarocks
+
+cd $TRAVIS_BUILD_DIR
+
+luarocks --version
+
+rm -rf $LUAROCKS_BASE
+
+if [ "$LUAJIT" == "yes" ]; then
+  rm -rf $LUAJIT_BASE;
+elif [ "$LUA" == "lua5.1" ]; then
+  rm -rf lua-5.1.5;
+elif [ "$LUA" == "lua5.2" ]; then
+  rm -rf lua-5.2.4;
+elif [ "$LUA" == "lua5.3" ]; then
+  rm -rf lua-5.3.1;
+fi

--- a/sailor
+++ b/sailor
@@ -96,7 +96,9 @@ local function test()
 	for i=2,#arg do
 		flags = flags..arg[i]..' '
 	end
-	os.execute('busted --helper=tests/bootstrap.lua '..flags..'tests/unit/* tests/functional/*')
+	local ok, code = os.execute('busted --helper=tests/bootstrap.lua '..flags..'tests/unit/* tests/functional/*')
+	if type(ok) == "number" then return ok end -- Lua 5.1 just returns the status code
+	return ok and 0 or 1 -- don't care about actual value
 end
 
 local function enable()
@@ -132,7 +134,7 @@ local function run()
 	if (arg[1] == 'create' or arg[1] == 'c') and arg[2] then
 		create()
 	elseif arg[1] == 'test' or arg[1] == 't' then
-		test()
+		return test()
 	elseif arg[1] == 'enable' and arg[2] then
 		enable()
 	else
@@ -140,4 +142,8 @@ local function run()
 	end
 end
 
-run()
+local exit_code = run()
+if exit_code and exit_code ~= 0 then
+	-- exit code sometimes is > 255 and fails to be propagated
+	os.exit(1, true)
+end

--- a/test/dev-app/conf/conf.lua
+++ b/test/dev-app/conf/conf.lua
@@ -1,3 +1,13 @@
+
+local db_driver, db_user, db_pass, db_name
+
+if os.getenv("TRAVIS") == "true" then
+	db_driver = assert(os.getenv("DB_DRIVER"))
+	db_user = assert(os.getenv("DB_USER"))
+	db_pass = os.getenv("DB_PASS")
+	db_name = os.getenv("DB_NAME")
+end
+
 local conf = {
 	sailor = {
 		app_name = 'Sailor! A Lua MVC Framework',
@@ -17,11 +27,11 @@ local conf = {
 
 	db = {
 		test = { -- current environment
-			driver = 'mysql',
+			driver = db_driver or 'mysql',
 			host = 'localhost',
-			user = '',
-			pass = '',
-			dbname = ''
+			user = db_user or '',
+			pass = db_pass or '',
+			dbname = db_name or ''
 		}
 	},
 


### PR DESCRIPTION
Adds the required files to enable integration with Travis.
Currently, it sets up MySQL and runs tests of the included development application (test/dev-app).

I had to change the config of the applicationa little, in order to change the DB driver, user, etc.

Also made some changes in the `sailor` binary, so errors when running Busted were correctly propagated (not caring much about actual error codes, just OK / FAIL).

And finally, enabled a matrix to run tests with:

 - Lua 5.1: passing
 - Lua 5.2: failing (cgilua still uses `module` and we build Lua with COMPAT flags disabled)
 - Lua 5.3: fails to install all dependencies (it complains abouts Copas)
 - LuaJIT 2.0.4: passing