### PR TITLE
Fix unintended global manipulations

### DIFF
--- a/src/latclient/moonshine.lua
+++ b/src/latclient/moonshine.lua
@@ -8,6 +8,7 @@ local M = {
 }
 
 local common = require "latclient.common"
+local loadstring = loadstring or load
 
 function M.get_header(s)
 	if M.js_served == false then

--- a/src/sailor.lua
+++ b/src/sailor.lua
@@ -180,7 +180,7 @@ function sailor.route(page)
         end
 
         local ctr
-        _, res = xpcall(function() ctr = require("controllers."..controller) end, error_404)
+        local _, res = xpcall(function() ctr = require("controllers."..controller) end, error_404)
         
         if ctr then
             local custom_path = ctr.path or (ctr.conf and ctr.conf.path)
@@ -193,7 +193,7 @@ function sailor.route(page)
             if not ctr[action] then return error_404() end
 
             -- run action
-            local _, res = xpcall(function() return ctr[action](page) end, error_handler)
+            _, res = xpcall(function() return ctr[action](page) end, error_handler)
             if res == 404 then return error_404() end
         end
 

--- a/src/sailor/db.lua
+++ b/src/sailor/db.lua
@@ -10,7 +10,7 @@ local main_conf = require "conf.conf"
 local conf = main_conf.db[main_conf.sailor.environment]
 local remy = require "remy"
 
-function detect()
+local function detect()
 	if conf == nil then error("DB environment not found.") return end
 	local m
 	if remy.detect() == remy.MODE_NGINX and conf.driver == "mysql" then

--- a/src/sailor/db/resty_mysql.lua
+++ b/src/sailor/db/resty_mysql.lua
@@ -84,7 +84,7 @@ end
 -- @return string or nil: if q is a string, returns the new escaped string. If q is a table
 --							it simply returns, since it already escaped the table's values
 
-function escape_string(s)
+local function escape_string(s)
 	-- Based on luajson code
 	-- https://github.com/harningt/luajson/blob/master/lua/json/encode/strings.lua
 	local matches = {

--- a/src/sailor/test.lua
+++ b/src/sailor/test.lua
@@ -28,7 +28,7 @@ end
 -- Loads tests fixtures into the database
 -- Warning, this will truncate the table, make sure you have configured a test database
 -- Returns table with objects created
-function load_fixtures(model_name)
+local function load_fixtures(model_name)
 	local Model = sailor.model(model_name)
 	local fixtures = require("tests.fixtures."..model_name) or {}
 	local objects = {}

--- a/src/web_utils/lp.lua
+++ b/src/web_utils/lp.lua
@@ -4,7 +4,7 @@
 -- @release $Id: lp.lua,v 1.15 2008/12/11 17:40:24 mascarenhas Exp $
 ----------------------------------------------------------------------------
 
-local assert, error, loadstring = assert, error, loadstring
+local assert, error = assert, error
 local find, format, gsub, strsub, char = string.find, string.format, string.gsub, string.sub, string.char
 local concat, tinsert = table.concat, table.insert
 local open = io.open


### PR DESCRIPTION
A linter detected that a bunch of globals are set that can be replaced with locals. Also fixes Lua 5.3 incompatibility in latclient/moonshine.lua (loadstring usage). Some other warnings not related to globals, not sure how to fix some of them:

```
src/sailor.lua:75:16: variable 'GETMULTI' is never accessed
src/sailor.lua:97:19: unused variable 'c'
src/sailor.lua:160:16: accessing uninitialized variable 'res'
src/sailor.lua:203:5: unreachable code
src/sailor.lua:240:11: unused variable 'model'
src/sailor/blank-app/tests/bootstrap_resty.lua:2:7: unused variable 't'
src/sailor/db/luasql_common.lua:79:8: value assigned to variable 'query' is unused
src/sailor/db/luasql_common.lua:151:2: value assigned to variable 'key' is unused
src/sailor/db/luasql_common.lua:251:19: accessing uninitialized variable 'key'
src/sailor/db/resty_mysql.lua:168:19: accessing uninitialized variable 'key'
src/sailor/db/resty_mysql.lua:175:8: unused variable 'helper'
src/sailor/model.lua:108:10: unused variable 'attr'
src/sailor/model.lua:136:8: unused variable 'key'
src/sailor/model.lua:137:8: unused variable 'attributes'
src/sailor/model.lua:172:8: unused variable 'attributes'
src/sailor/model.lua:278:8: unused variable 'key'
src/sailor/page.lua:13:7: unused variable 'match'
src/sailor/session.lua:10:7: unused variable 'utils'
src/sailor/test.lua:13:7: unused variable 'db_conf'
src/web_utils/session.lua:12:30: unused variable 'strsub'
```